### PR TITLE
Makefile : update to use $(CC) to link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RM = /bin/rm
 DRIVER_BIN = qedrv_bin
 SRCS = heap.c chan_ops.c debug.c resolv.c socket.c qedrv.c w5300.c
 $(DRIVER_BIN): $(OBJS)
-	ld -o$(DRIVER_BIN) -ms -screspr.o $(OBJS) -lgcc
+	$(CC) -o $(DRIVER_BIN) -Wl,-ms -Wl,-screspr.o $(OBJS) -lgcc
 .PHONY: clean
 clean:
 	$(RM) -f *.o *.s *.MAP $(DRIVER_BIN)


### PR DESCRIPTION
Passing arguments to linker with -Wl,xxxx means we don't need to worry about getting the correct version of ld and dont have to rely on path order.

Signed-off-by: Graeme Gregory <graeme@xora.org.uk>